### PR TITLE
Improved table data display 

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,7 +1,7 @@
 export function parseQuery(query) {
     const parts = query.split('.');
-    return parts.map(part => {
-        const match = part.match(/(\w+)\[(.*)\]/);
+    const parsed = parts.map(part => {
+        const match = part.match(/(\w*)\[(.*)\]/);
         if (match) {
             return {
                 type: 'filter',
@@ -14,6 +14,17 @@ export function parseQuery(query) {
             name: part
         };
     });
+    let first = true;
+    for (const q of parsed) {
+        if (first) {
+            first = false;
+        } else {
+            if (!q.field) {
+                throw Error(`Filter without field: ${query}`);
+            }
+        }
+    }
+    return parsed;
 }
 
 function parseCondition(condition) {
@@ -60,7 +71,11 @@ export function executeQuery(json, parsedQuery) {
             result = result[part.name];
         } else if (part.type === 'filter') {
             const { conditions, operators } = parseCondition(part.condition);
-            const filteredResult = result[part.field].filter(item => {
+            let arr = result;
+            if (part.field) {
+                arr = result[part.field];
+            }
+            const filteredResult = arr.filter(item => {
                 return evaluateConditions(item, conditions, operators);
             });
             // Store the filtered result in finalResult

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -19,7 +19,7 @@ export function parseQuery(query) {
         if (first) {
             first = false;
         } else {
-            if (!q.field) {
+            if (q.type === "filter" && !q.field) {
                 throw Error(`Filter without field: ${query}`);
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ export default class QJSON extends Plugin {
 				return;
 			}
 			let id;
-			id = source.match(/#qj-id: (\d+)/);
+			id = source.match(/^#qj-id: (\d+)$/m);
 			if (id) id = id[1];
 			// check if id is a number
 			if (isNaN(parseInt(id))) {
@@ -35,7 +35,7 @@ export default class QJSON extends Plugin {
 			let query;
 
 			if (source.includes('#qj-query:')) {
-				query = source.match(/#qj-query: (.+)/);
+				query = source.match(/^#qj-query: ([^\n\r]+)$/m);
 				if (query) {
 					query = query[1];
 				} else {
@@ -48,10 +48,54 @@ export default class QJSON extends Plugin {
 
 
 			let format;
+			let selectedFields;
 
 			if (source.includes('#qj-format:')) {
-				format = source.match(/#qj-format: (.+)/);
+				format = source.match(/^#qj-format: ([^\[\n\r ]+)(?:\s*\[([^\]\n\r]+)\])?$/m);
 				if (format) {
+					if (format[2]) {
+						const formats = format[2].split(",");
+						selectedFields = formats.map(f => {
+							const fsplit = f.split(':');
+							const hsplit = fsplit[0].split('=', 2);
+							const flags = hsplit[0];
+							const name = hsplit[1] || null;
+							const field = fsplit[1];
+							const field2 = fsplit[2] || null;
+							return {
+								header: flags.includes('h'),
+								bold: flags.includes('b'),
+								comma: flags.includes('c'),
+								br: flags.includes('n'),
+								link: flags.includes('l'),
+								name: name,
+								field: field,
+								field2: field2
+							};
+						});
+						let first = true;
+						for (const sf of selectedFields) {
+							if (first) {
+									first = false;
+							} else {
+								if (sf.header) {
+									new Notice('Field format "header" is not in first position');
+									el.createEl('pre', { text: 'Field format "header" is not in first position' });
+									return;
+								}
+							}
+							if (!(sf.field)) {
+								new Notice('Field format is missing field name');
+								el.createEl('pre', { text: 'Field format is missing field name' });
+								return;
+							}
+							if (sf.link && !sf.field2) {
+								new Notice( 'Field format link is missing second field name');
+								el.createEl('pre', { text: 'Field format link is missing second field name' });
+								return;
+							}
+						}
+					}
 					format = format[1];
 				} else {
 					new Notice('No format found');
@@ -64,7 +108,7 @@ export default class QJSON extends Plugin {
 
 			if (!source.includes('#qj-hide-id')) {
 				try {
-					desc = source.match(/#qj-desc: (.+)/);
+					desc = source.match(/^#qj-desc: ([^\n\r]+)$/m);
 					if (desc) desc = desc[1];
 				} catch (e) {
 					desc = "»»» QJSON «««";
@@ -80,59 +124,171 @@ export default class QJSON extends Plugin {
 			}
 
 			if (source.includes('#qj-file:')) {
-				const file = source.match(/#qj-file: (.+)/);
+				const file = source.match(/^#qj-file: ([^\n\r]+)$/m);
 				if (file) {
-					source = await this.app.vault.adapter.read(file[1]);
+					try {
+						// Code that might throw an error
+						source = await this.app.vault.adapter.read(file[1]);
+					} catch (error) {
+						console.error('File load error:', error);
+						new Notice("file not found");
+						el.createEl('pre', { text: 'File not found' });
+						return;
+					}
 				} else {
-					new Notice('No file found');
-					el.createEl('pre', { text: 'No file found' });
+					new Notice('No file given');
+					el.createEl('pre', { text: 'No file given' });
 					return;
 				}
 			}
 
 			const json = JSON.parse(source);
 
-			if (query) {
-				const result = executeQuery(json, query);
+			let result = json;
+			let fieldResult;
+			console.log(result, format, selectedFields);
 
-				if (format && query[query.length - 1].type === "field") {
+			if (query) {
+				result = executeQuery(json, query);
+				fieldResult = (query[query.length - 1].type === "field");
+			} else {
+				fieldResult = !Array.isArray(result);
+			}
+			console.log(result, fieldResult);
+
+			if (!format || format === "json") {
+				el.createEl('pre', { text: JSON.stringify(result, null, 2), cls: 'QJSON-' + id + ' cdQjson ' + showJson });
+			} else {
+				if (fieldResult) {
+					/*if (selectedFields || !(typeof result === 'object')) {
+						new Notice("Non-object field queries ignore field formats");
+					}*/
+					if (selectedFields) {
+						new Notice("Field queries currently ignore field formats");
+					}
 					if (format === "list") {
 						const ul = el.createEl('ul');
 						if (typeof result === 'string') {
 							ul.createEl('li', { text: result });
-						} else {
+						} else if (Array.isArray(result)) {
 							for (let i = 0; i < result.length; i++) {
-								ul.createEl('li', { text: JSON.stringify(result[i], null, 2) });
+								ul.createEl('li', { text: formatOutput(result[i]) });
 							}
+						} else if (typeof result === 'object') {
+							for (const key of result) {
+								const tr = tbody.createEl('tr');
+								tr.createEl('th', { text: key });
+								tr.createEl('td', { text: formatOutput(result[key]) });
+							}
+						} else {
+							new Notice('unsupported object type');
 						}
 					} else if (format === "table") {
 						const table = el.createEl('table');
 						const tbody = table.createEl('tbody');
-						if (typeof result === 'object') {
-							for (const key in result) {
-								const tr = tbody.createEl('tr');
-								tr.createEl('th', { text: key });
-								tr.createEl('td', { text: JSON.stringify(result[key], null, 2) });
-							}
-						} else {
+						if (typeof result === 'string') {
 							const tr = tbody.createEl('tr');
 							tr.createEl('td', { text: result });
+						} else if (Array.isArray(result)) {
+							for (let i = 0; i < result.length; i++) {
+								const tr = tbody.createEl('tr');
+								tr.createEl('td', { text: formatOutput(result[i]) });
+							}
+						} else if (typeof result === 'object') {
+							for (const key of result) {
+								const tr = tbody.createEl('tr');
+								tr.createEl('th', { text: key });
+								tr.createEl('td', { text: formatOutput(result[key]) });
+							}
+						} else {
+							new Notice('unsupported object type');
 						}
 					} else if (format === "img") {
 						if (typeof result === 'string') {
 							el.createEl('img', { attr: { src: result } });
-						} else {
+						} else if (Array.isArray(result)) {
+							let notString = false;
 							for (let i = 0; i < result.length; i++) {
-								el.createEl('img', { attr: { src: result[i], width: 100, height: 100 } });
+								if (typeof result[i] === 'string') {
+									el.createEl('img', { attr: { src: result[i], width: 100, height: 100 } });
+								} else {
+									notString = true;
+								}
+							}
+							if (notString) {
+								new Notice('one or more entries could not be rendered');
+							}
+						} else {
+							new Notice('format "img" does not support objects');
+						}
+					}
+				} else {
+					// filtered or raw JSON works here
+					if (!Array.isArray(result)) {
+						new Notice('Table & list can only be created from array');
+						el.createEl('pre', { text: 'Table & list can only be created from array' });
+						return;
+					}
+					let oEl;
+					let titleNum = 1;
+					if (format === "list") {
+						if (selectedFields[0].header && selectedFields[0].name) {
+							formatElement(el, selectedFields[0], null, selectedFields[0].name);
+						}
+						oEl = el.createEl('ul', { attr:{ style:"list-style-position: outside;"}});
+						console.log(el, oEl);
+					} else if (format === "table") {
+						const table = el.createEl('table');
+						const thead = table.createEl('thead');
+						oEl = table.createEl('tbody');
+						const tr = thead.createEl('tr');
+						for (const select of selectedFields) {
+							const name = select.name || select.field;
+							let td = tr.createEl('td');
+							td.createEl('b', {text: name});
+						}
+					}
+					let eEl;
+					for (const entry of result) {
+						if (format === "list") {
+							let hEl = oEl.createEl('li');
+							if (selectedFields[0].header) {
+								formatElement(hEl, selectedFields[0], entry);
+							} else {
+								hEl.appendText(""+(titleNum++));
+							}
+
+							eEl = hEl.createEl('lu', { attr:{ style:"list-style-position: inside;"}});
+						} else if (format === "table") {
+							eEl = oEl.createEl('tr');
+						}
+						for (const select of selectedFields) {
+							if (format === "list") {
+								if (select.header) {
+									// header value is already upper list content
+									continue;
+								}
+								let fEl = eEl.createEl('li');
+								if (select.name) {
+									fEl.appendText(select.name);
+								} else {
+									fEl.appendText(select.field);
+								}
+								fEl.appendText(': ');
+								formatElement(fEl, select, entry);
+							} else if (format === "table") {
+								let fEl;
+								if (select.header) {
+									fEl = eEl.createEl('th');
+								} else {
+									fEl = eEl.createEl('td');
+								}
+								formatElement(fEl, select, entry);
 							}
 						}
 					}
-					return;
 				}
-
-				el.createEl('pre', { text: JSON.stringify(result, null, 2), cls: 'QJSON-' + id + ' cdQjson ' + showJson });
-			} else {
-				el.createEl('pre', { text: JSON.stringify(json, null, 2), cls: 'QJSON-' + id + ' cdQjson ' + showJson });
+				//return;
 			}
 
 			updateStatusBarCounter();
@@ -255,4 +411,57 @@ export default class QJSON extends Plugin {
 function getJSONPath(json: Object, path: string) {
 	if (path === '') return json;
 	return path.split('.').reduce((acc, key) => acc[key], json);
+}
+
+function formatElement(parent: Element, format: Object, json: Object, text?: string) {
+	if (!text) {
+		const textJson = json[format.field];
+		if (Array.isArray(textJson)) {
+			text = textJson.map(j => formatOutput(j));
+		} else {
+			text = formatOutput(textJson);
+		}
+	}
+
+	let el;
+	if (format.bold) {
+		el = parent.createEl('b');
+	} else {
+		el = parent;
+	}
+	
+	if (Array.isArray(text)) {
+		let idx = 0;
+		for (let t of text) {
+			if (format.link) {
+				el.createEl('a', {text: t, href: json[format.field2][idx]});
+			} else {
+				el.appendText(t);
+			}
+			if (idx < text.length-1) {
+				if (format.comma) {
+					el.appendText(', ');
+				} else if (format.br) {
+					el.createEl('br');
+				} else {
+					el.appendText(' ');
+				}
+			}
+			idx++;
+		}
+	} else {
+		if (format.link) {
+			el.createEl('a', {text: text, href: json[format.field2]});
+		} else {
+			el.appendText(text);
+		}
+	}
+}
+
+function formatOutput(json: Object) {
+	if (typeof json === 'string') {
+		return json;
+	} else {
+		return  JSON.stringify(json, null, 2);
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,8 +140,12 @@ export default class QJSON extends Plugin {
 					el.createEl('pre', { text: 'No file given' });
 					return;
 				}
+			} else {
+				console.log(source);
+				source = source.replace(/^#qj-[a-z]+: .*$/gm, "");
+				console.log(source);
 			}
-
+			
 			const json = JSON.parse(source);
 
 			let result = json;

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ export default class QJSON extends Plugin {
 			let selectedFields;
 
 			if (source.includes('#qj-format:')) {
-				format = source.match(/^#qj-format: ([^\[\n\r ]+)(?:\s*\[([^\]\n\r]+)\])?$/m);
+				format = source.match(/^#qj-format: ([^\[\n\r ]+)(?:[\t\f ]*\[([^\]\n\r]+)\])?$/m);
 				if (format) {
 					if (format[2]) {
 						const formats = format[2].split(",");
@@ -229,6 +229,24 @@ export default class QJSON extends Plugin {
 						el.createEl('pre', { text: 'Table & list can only be created from array' });
 						return;
 					}
+					if (!selectedFields && result.length > 0) {
+						// just use all fields from the first element
+						if (Array.isArray(result[0]) || typeof result[0] !== 'object') {
+							result = [{entry: result}];
+						}
+						selectedFields = Object.entries(result[0]).map(([k,v],i) => {return {
+								header: false,
+								bold: false,
+								comma: false,
+								br: false,
+								link: false,
+								name: null,
+								field: k,
+								field2: null
+							};
+						});
+					}
+					console.log(selectedFields, result);
 					let oEl;
 					let titleNum = 1;
 					if (format === "list") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,16 +141,13 @@ export default class QJSON extends Plugin {
 					return;
 				}
 			} else {
-				console.log(source);
 				source = source.replace(/^#qj-[a-z]+: .*$/gm, "");
-				console.log(source);
 			}
 			
 			const json = JSON.parse(source);
 
 			let result = json;
 			let fieldResult;
-			console.log(result, format, selectedFields);
 
 			if (query) {
 				result = executeQuery(json, query);
@@ -158,7 +155,6 @@ export default class QJSON extends Plugin {
 			} else {
 				fieldResult = !Array.isArray(result);
 			}
-			console.log(result, fieldResult);
 
 			if (!format || format === "json") {
 				el.createEl('pre', { text: JSON.stringify(result, null, 2), cls: 'QJSON-' + id + ' cdQjson ' + showJson });
@@ -240,7 +236,6 @@ export default class QJSON extends Plugin {
 							formatElement(el, selectedFields[0], null, selectedFields[0].name);
 						}
 						oEl = el.createEl('ul', { attr:{ style:"list-style-position: outside;"}});
-						console.log(el, oEl);
 					} else if (format === "table") {
 						const table = el.createEl('table');
 						const thead = table.createEl('thead');

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,11 @@ export default class QJSON extends Plugin {
 								el.createEl('pre', { text: 'Field format link is missing second field name' });
 								return;
 							}
+							if (sf.template && !sf.name) {
+								new Notice( 'Field format with template must provide name');
+								el.createEl('pre', { text: 'Field format with template must provide name' });
+								return;
+							}
 						}
 					}
 					format = format[1];

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,10 +230,10 @@ export default class QJSON extends Plugin {
 						return;
 					}
 					if (!selectedFields && result.length > 0) {
-						// just use all fields from the first element
 						if (Array.isArray(result[0]) || typeof result[0] !== 'object') {
-							result = [{entry: result}];
+							result = result.map(e => { return {entry: e};});
 						}
+						// just use all fields from the first element
 						selectedFields = Object.entries(result[0]).map(([k,v],i) => {return {
 								header: false,
 								bold: false,
@@ -246,7 +246,6 @@ export default class QJSON extends Plugin {
 							};
 						});
 					}
-					console.log(selectedFields, result);
 					let oEl;
 					let titleNum = 1;
 					if (format === "list") {


### PR DESCRIPTION
Hello,

I really liked the idea of this plugin, but I wanted to display array object content in a very customizable way.
So I added a couple of features and now it works for me.

The main change is the possibility to add column formatting:
`#qj-format: table[<flags>:<field or template>:<link field>=<custom name>,<flags>:<field or template>:<link field>=<custom name>,...]`
For example:
`#qj-format: table[h:title=Name,:value,b:test=Value 2]`
with a template:
`#qj-format: table[:"Custom {value} of {test}"=Something]`

The following flags are implemented:
- **b**: display bold
- **h**: header column/field (only allowed in the first entry)
- **l**: create a link - a second field name must be provided, which contains the link URL
- **c**: if a list of values is the content, use comma separation for the entries
- **n**: if a list of values is the content, use new-line/<BR> separation for the entries


This is a quick demonstration of the new features:
[JSON Query Test.md](https://github.com/user-attachments/files/18265822/JSON.Query.Test.md)
[test01.json](https://github.com/user-attachments/files/18265823/test01.json)

Feel free to use all ideas or cherry-pick as you see fit.

There are also some other minor fixes and changes, e.g.:
- JSON content in markdown can now actually be used
- better matching of qj-headers
- Allow filtering on top-level JSON arrays