### PR TITLE
fix(parse): fix stripping of flag with no parameters

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,7 @@ export default class QJSON extends Plugin {
 					return;
 				}
 			} else {
-				source = source.replace(/^#qj-[a-z]+: .*$/gm, "");
+				source = source.replace(/^#qj-[a-z]+(: )?.*$/gm, "");
 			}
 			
 			const json = JSON.parse(source);


### PR DESCRIPTION
Flags like `#qj-id: 24` are stripped by the regex, but flags that have no parameter like `qj-show-json` and `#qj-hide-id` are not.

The reason is that the regex expect to match the character sequence `: ` in it. But these flags do not match it and are not stripped from the input data.

This PR updates the regex to make the character sequence `: ` optional, thus making the flags with no parameters match.