### PR TITLE
fix(desc): add default description when parsing `#qj-desc` flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,7 @@ export default class QJSON extends Plugin {
 			if (!source.includes('#qj-hide-id')) {
 				try {
 					desc = source.match(/^#qj-desc: ([^\n\r]+)$/m);
-					if (desc) desc = desc[1];
+					desc = desc[1] ?? "»»» QJSON «««";
 				} catch (e) {
 					desc = "»»» QJSON «««";
 				}


### PR DESCRIPTION
If the regex does not find a match, `desc[1]` is null but the code does not throw an exception.

Also, I don't know why my ID and Desc aren't coloured like in your GIF. Did you use a CSS snippet?